### PR TITLE
Add reusable CPF validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # rmmg-wix
+
+Projeto de exemplo com função de validação de CPF reutilizável no backend e no frontend.
+
+## Executando
+
+```
+npm test
+```

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,4 @@
+import { validateCpf } from '../shared/cpf.js';
+
+const sample = '529.982.247-25';
+console.log('Backend validation:', validateCpf(sample));

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,4 @@
+import { validateCpf } from '../shared/cpf.js';
+
+const sample = '11144477735';
+console.log('Frontend validation:', validateCpf(sample));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "rmmg-wix",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node backend/index.js && node frontend/index.js"
+  }
+}

--- a/shared/cpf.js
+++ b/shared/cpf.js
@@ -1,0 +1,18 @@
+export function calculateCpfCheckDigits(base) {
+  let factor = base.length + 1;
+  let sum = 0;
+  for (const char of base) {
+    sum += parseInt(char, 10) * factor--;
+  }
+  let result = (sum * 10) % 11;
+  return result === 10 ? 0 : result;
+}
+
+export function validateCpf(cpf) {
+  const digits = cpf.replace(/\D/g, '');
+  if (digits.length !== 11) return false;
+  if (digits.split('').every((d) => d === digits[0])) return false;
+  const first = calculateCpfCheckDigits(digits.slice(0, 9));
+  const second = calculateCpfCheckDigits(digits.slice(0, 10));
+  return digits.endsWith(`${first}${second}`);
+}


### PR DESCRIPTION
## Summary
- add shared CPF validation that computes check digits and uses regex only to remove non-numeric characters
- demonstrate reuse in backend and frontend modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e3e39e9883308ba801dadb42f9e7