### PR TITLE
Fix CNPJ field key in member registration

### DIFF
--- a/backend/registerMember.jsw
+++ b/backend/registerMember.jsw
@@ -19,7 +19,7 @@ export async function registerMember({ email, password, cnpj }) {
 
     const duplicate = await wixData
       .query('Members/FullData')
-      .eq('cnpj', cleanCnpj)
+      .eq('CNPJ', cleanCnpj)
       .find();
 
     if (duplicate.items.length > 0) {
@@ -31,7 +31,7 @@ export async function registerMember({ email, password, cnpj }) {
     const memberData = {
       _id: user.id,
       email,
-      cnpj: cleanCnpj,
+      CNPJ: cleanCnpj,
     };
 
     await wixData.insert('Members/FullData', memberData);


### PR DESCRIPTION
## Summary
- use correct `CNPJ` field key when querying and inserting member data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894eb3fca748330b6566d53416d6f46